### PR TITLE
Refactor topology code gen

### DIFF
--- a/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopComponentInstances.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopComponentInstances.scala
@@ -13,19 +13,22 @@ case class TopComponentInstances(
   private val bannerComment = "Component instances"
 
   def getMembers: List[CppDoc.Member] = {
-    val hppLines = getHppLines
-    lazy val cppLines = getCppLines
-    lazy val comment = CppDocWriter.writeBannerComment(bannerComment)
-    guardedList (!hppLines.isEmpty) (
-      List(
-        linesMember(comment, CppDoc.Lines.Both),
-        linesMember(hppLines, CppDoc.Lines.Hpp),
-        linesMember(cppLines, CppDoc.Lines.Cpp)
+    val hppLinesMembers = getHppLinesMembers
+    val cppLinesMembers = List(linesMember(getCppLines, CppDoc.Lines.Cpp))
+    lazy val commentMembers = List(
+      linesMember(
+        CppDocWriter.writeBannerComment(bannerComment),
+        CppDoc.Lines.Both
       )
+    )
+    List.concat(
+      guardedList (!hppLinesMembers.isEmpty) (commentMembers),
+      hppLinesMembers,
+      cppLinesMembers
     )
   }
 
-  private def getHppLines = {
+  private def getHppLinesMembers = {
     def getCode(ci: ComponentInstance): List[Line] = {
       val implType = getImplType(ci)
       val instanceName = ci.getUnqualifiedName
@@ -35,7 +38,8 @@ case class TopComponentInstances(
       )
       Line.blank :: wrapInNamespaceLines(ci.qualifiedName.qualifier, instLines)
     }
-    instances.flatMap(getCode)
+    val hppLines = instances.flatMap(getCode)
+    guardedList (!hppLines.isEmpty) (List(linesMember(hppLines, CppDoc.Lines.Hpp)))
   }
 
   private def getCppLines = {

--- a/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopComponentInstances.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopComponentInstances.scala
@@ -12,17 +12,21 @@ case class TopComponentInstances(
 
   private val bannerComment = "Component instances"
 
-  def getHppLines: List[Line] = addBannerComment(
-    bannerComment,
-    getDeclLines
-  )
+  def getMembers: List[CppDoc.Member] = {
+    val hppLines = getHppLines
+    lazy val cppLines = getCppLines
+    lazy val comment = CppDocWriter.writeBannerComment(bannerComment)
+    hppLines match {
+      case Nil => Nil
+      case _ => List(
+        linesMember(comment, CppDoc.Lines.Both),
+        linesMember(hppLines, CppDoc.Lines.Hpp),
+        linesMember(cppLines, CppDoc.Lines.Cpp)
+      )
+    }
+  }
 
-  def getCppLines: List[Line] = addBannerComment(
-    bannerComment,
-    getDefLines
-  )
-
-  private def getDeclLines = {
+  private def getHppLines = {
     def getCode(ci: ComponentInstance): List[Line] = {
       val implType = getImplType(ci)
       val instanceName = ci.getUnqualifiedName
@@ -35,7 +39,7 @@ case class TopComponentInstances(
     flattenWithBlankPrefix(instances.map(getCode))
   }
 
-  private def getDefLines = {
+  private def getCppLines = {
     def getCode(ci: ComponentInstance): List[Line] = {
       val implType = getImplType(ci)
       val instanceName = ci.getUnqualifiedName

--- a/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopComponentInstances.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopComponentInstances.scala
@@ -16,14 +16,13 @@ case class TopComponentInstances(
     val hppLines = getHppLines
     lazy val cppLines = getCppLines
     lazy val comment = CppDocWriter.writeBannerComment(bannerComment)
-    hppLines match {
-      case Nil => Nil
-      case _ => List(
+    guardedList (!hppLines.isEmpty) (
+      List(
         linesMember(comment, CppDoc.Lines.Both),
         linesMember(hppLines, CppDoc.Lines.Hpp),
         linesMember(cppLines, CppDoc.Lines.Cpp)
       )
-    }
+    )
   }
 
   private def getHppLines = {
@@ -34,9 +33,9 @@ case class TopComponentInstances(
         s"""|//! $instanceName
             |extern $implType $instanceName;"""
       )
-      wrapInNamespaceLines(ci.qualifiedName.qualifier, instLines)
+      Line.blank :: wrapInNamespaceLines(ci.qualifiedName.qualifier, instLines)
     }
-    flattenWithBlankPrefix(instances.map(getCode))
+    instances.flatMap(getCode)
   }
 
   private def getCppLines = {
@@ -48,9 +47,9 @@ case class TopComponentInstances(
           s"$implType $instanceName(FW_OPTIONAL_NAME($q$instanceName$q));"
         )
       )
-      wrapInNamespaceLines(ci.qualifiedName.qualifier, instLines)
+      Line.blank :: wrapInNamespaceLines(ci.qualifiedName.qualifier, instLines)
     }
-    flattenWithBlankPrefix(instances.map(getCode))
+    instances.flatMap(getCode)
   }
 
   private def getImplType(ci: ComponentInstance) = {

--- a/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopComponentInstances.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopComponentInstances.scala
@@ -10,21 +10,20 @@ case class TopComponentInstances(
   aNode: Ast.Annotated[AstNode[Ast.DefTopology]]
 ) extends TopologyCppWriterUtils(s, aNode) {
 
-  private val bannerComment = "Component instances"
-
   def getMembers: List[CppDoc.Member] = {
     val instanceMembers = getInstanceMembers
-    lazy val commentMembers = List(
-      linesMember(
-        CppDocWriter.writeBannerComment(bannerComment),
-        CppDoc.Lines.Both
-      )
-    )
     List.concat(
-      guardedList (!instanceMembers.isEmpty) (commentMembers),
+      guardedList (!instanceMembers.isEmpty) (List(getCommentMember)),
       instanceMembers
     )
   }
+
+  private val bannerComment = "Component instances"
+
+  private def getCommentMember = linesMember(
+    CppDocWriter.writeBannerComment(bannerComment),
+    CppDoc.Lines.Both
+  )
 
   private def getInstanceMembers = {
     def getMembers(ci: ComponentInstance): List[CppDoc.Member] = {

--- a/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopComponentInstances.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopComponentInstances.scala
@@ -29,7 +29,7 @@ case class TopComponentInstances(
     def getMembers(ci: ComponentInstance): List[CppDoc.Member] = {
       val implType = getImplType(ci)
       val instanceName = ci.getUnqualifiedName
-      val hpp = linesMember(
+      val hppMember = linesMember(
         lines(
           s"""|
               |//! $instanceName
@@ -37,7 +37,7 @@ case class TopComponentInstances(
         ),
         CppDoc.Lines.Hpp
       )
-      val cpp = {
+      val cppMember = {
         val instLines = getCodeLinesForPhase (CppWriter.Phases.instances) (ci).getOrElse(
           lines(
             s"""|
@@ -46,7 +46,7 @@ case class TopComponentInstances(
         )
         linesMember(instLines, CppDoc.Lines.Cpp)
       }
-      wrapInNamespaces(ci.qualifiedName.qualifier, List(hpp, cpp))
+      wrapInNamespaces(ci.qualifiedName.qualifier, List(hppMember, cppMember))
     }
     instances.flatMap(getMembers)
   }

--- a/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopologyCppWriter.scala
+++ b/compiler/lib/src/main/scala/codegen/CppWriter/TopologyCppWriter/TopologyCppWriter.scala
@@ -31,6 +31,9 @@ case class TopologyCppWriter(
       getTopologyMembers
     )
 
+  private def getComponentInstanceMembers =
+    TopComponentInstances(s, aNode).getMembers
+
   private def getIncludeMembers: List[CppDoc.Member] = {
     val hpp = {
       val strings = (
@@ -51,15 +54,6 @@ case class TopologyCppWriter(
         CppDoc.Lines.Cpp
       )
     }
-    List(hpp, cpp)
-  }
-
-  private def getComponentInstanceMembers: List[CppDoc.Member] = {
-    val hpp = linesMember(TopComponentInstances(s, aNode).getHppLines)
-    val cpp = linesMember(
-      TopComponentInstances(s, aNode).getCppLines,
-      CppDoc.Lines.Cpp
-    )
     List(hpp, cpp)
   }
 

--- a/compiler/tools/fpp-to-cpp/test/top/BasicTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/BasicTopologyAc.ref.cpp
@@ -11,23 +11,32 @@
 // ----------------------------------------------------------------------
 
 namespace M {
+
   Active active1(FW_OPTIONAL_NAME("active1"));
+
 }
 
 namespace M {
   Active active2;
+
 }
 
 namespace M {
+
   Active active3(FW_OPTIONAL_NAME("active3"));
+
 }
 
 namespace M {
+
   Passive passive1(FW_OPTIONAL_NAME("passive1"));
+
 }
 
 namespace M {
+
   ConcretePassive passive2(FW_OPTIONAL_NAME("passive2"));
+
 }
 
 namespace M {

--- a/compiler/tools/fpp-to-cpp/test/top/BasicTopologyAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/top/BasicTopologyAc.ref.hpp
@@ -16,28 +16,38 @@
 // ----------------------------------------------------------------------
 
 namespace M {
+
   //! active1
   extern Active active1;
+
 }
 
 namespace M {
+
   //! active2
   extern Active active2;
+
 }
 
 namespace M {
+
   //! active3
   extern Active active3;
+
 }
 
 namespace M {
+
   //! passive1
   extern Passive passive1;
+
 }
 
 namespace M {
+
   //! passive2
   extern ConcretePassive passive2;
+
 }
 
 namespace M {

--- a/compiler/tools/fpp-to-cpp/test/top/CommandsTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/CommandsTopologyAc.ref.cpp
@@ -11,11 +11,15 @@
 // ----------------------------------------------------------------------
 
 namespace M {
+
   C c1(FW_OPTIONAL_NAME("c1"));
+
 }
 
 namespace M {
+
   C c2(FW_OPTIONAL_NAME("c2"));
+
 }
 
 namespace M {

--- a/compiler/tools/fpp-to-cpp/test/top/CommandsTopologyAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/top/CommandsTopologyAc.ref.hpp
@@ -15,13 +15,17 @@
 // ----------------------------------------------------------------------
 
 namespace M {
+
   //! c1
   extern C c1;
+
 }
 
 namespace M {
+
   //! c2
   extern C c2;
+
 }
 
 namespace M {

--- a/compiler/tools/fpp-to-cpp/test/top/HealthTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/HealthTopologyAc.ref.cpp
@@ -11,15 +11,21 @@
 // ----------------------------------------------------------------------
 
 namespace M {
+
   C c1(FW_OPTIONAL_NAME("c1"));
+
 }
 
 namespace M {
+
   C c2(FW_OPTIONAL_NAME("c2"));
+
 }
 
 namespace M {
+
   Svc::Health health(FW_OPTIONAL_NAME("health"));
+
 }
 
 namespace M {

--- a/compiler/tools/fpp-to-cpp/test/top/HealthTopologyAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/top/HealthTopologyAc.ref.hpp
@@ -16,18 +16,24 @@
 // ----------------------------------------------------------------------
 
 namespace M {
+
   //! c1
   extern C c1;
+
 }
 
 namespace M {
+
   //! c2
   extern C c2;
+
 }
 
 namespace M {
+
   //! health
   extern Svc::Health health;
+
 }
 
 namespace M {

--- a/compiler/tools/fpp-to-cpp/test/top/ParamsTopologyAc.ref.cpp
+++ b/compiler/tools/fpp-to-cpp/test/top/ParamsTopologyAc.ref.cpp
@@ -11,11 +11,15 @@
 // ----------------------------------------------------------------------
 
 namespace M {
+
   C c1(FW_OPTIONAL_NAME("c1"));
+
 }
 
 namespace M {
+
   C c2(FW_OPTIONAL_NAME("c2"));
+
 }
 
 namespace M {

--- a/compiler/tools/fpp-to-cpp/test/top/ParamsTopologyAc.ref.hpp
+++ b/compiler/tools/fpp-to-cpp/test/top/ParamsTopologyAc.ref.hpp
@@ -15,13 +15,17 @@
 // ----------------------------------------------------------------------
 
 namespace M {
+
   //! c1
   extern C c1;
+
 }
 
 namespace M {
+
   //! c2
   extern C c2;
+
 }
 
 namespace M {


### PR DESCRIPTION
@jwest115 please take a look at these proposed changes:

* Existing way: For each component instance, for each of the hpp and cpp parts, generate lines and wrap them in namespace lines.
* Proposed way: For each component instance, wrap the pair of hpp and cpp parts in namespace members.

Both ways are good, but the proposed way may be more "with the grain" of how CppDoc works. It also eliminates some duplicate code.

Note that in CppDoc, line members may generate code for hpp, cpp, or both; but non-line members generate code for both. For example, a function member generates a function prototype to hpp and a function implementation to cpp. For variable declarations, there's less consistent structure to latch onto in C++, so there's no "variable declaration" member; but you can use a similar pattern, as I did here.